### PR TITLE
respect go_package option for external messages

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -111,8 +111,8 @@ func GenerateFile(p *protogen.Plugin, f *protogen.File, cfg *Config) *protogen.G
 				IsStreamingServer: method.Desc.IsStreamingServer(),
 			}
 
-			input := method.Input.GoIdent.GoName
-			output := method.Output.GoIdent.GoName
+			input := g.QualifiedGoIdent(method.Input.GoIdent)
+			output := g.QualifiedGoIdent(method.Output.GoIdent)
 			if cfg.Standalone {
 				// handle emptypb
 				if input != emptypbPackage.Ident("Empty").GoName {


### PR DESCRIPTION
I got a compile error on generated file, when there was a gRPC method with an externally imported message as an interface.
This is because it is trying to use it without the identifier of the imported package, and I would like to fix it.

The actual content is to use `g.QualifiedGoIdent(method.Input.GoIdent)` instead of `method.Input.GoIdent.GoName`.
This way, the Identifier is appropriately converted depending on whether it is inside or outside the package of the generated file.

I have already verified that the generated files are compile-error-free in the problematic environment.